### PR TITLE
Add MATLAB FCHEV fault-tolerant MPC and DP simulation

### DIFF
--- a/FTMPC_FCHEV/README.md
+++ b/FTMPC_FCHEV/README.md
@@ -1,0 +1,33 @@
+# Fault-Tolerant MPC for FCHEV
+
+This folder contains MATLAB scripts reproducing the simulation study from
+*Fault-Tolerant Model Predictive Control for Fuel Cell Hybrid Electric Vehicles*.
+
+`runMobypostFTMPC.m` is the main entry point. It generates a stochastic
+mail delivery driving cycle, applies the four fault scenarios and compares
+the proposed fault-tolerant MPC (FTMPC) with a simplified
+Fault-Tolerant Dynamic Programming (FTDP) benchmark. The script prints a
+summary table of hydrogen consumption and computation time for each
+scenario.
+
+The implementation relies solely on MATLAB/Octave and the Optimization
+Toolbox for `quadprog`. For environments without `quadprog`, replace it
+with any QP solver compliant with the same interface.
+
+## Files
+- `runMobypostFTMPC.m` – main script
+- `generateDriveCycle.m` – stochastic drive cycle generator
+- `vehiclePowerDemand.m` – vehicle dynamics and power demand calculation
+- `simulateScenario.m` – wrapper executing FTMPC and FTDP
+- `simulateFTMPC.m` – fault-tolerant MPC controller
+- `simulateFTDP.m` – simplified dynamic programming benchmark
+
+## Usage
+From MATLAB or Octave, run:
+```matlab
+runMobypostFTMPC
+```
+
+The script outputs a table summarising the hydrogen consumption and
+relative performance.
+

--- a/FTMPC_FCHEV/generateDriveCycle.m
+++ b/FTMPC_FCHEV/generateDriveCycle.m
@@ -1,0 +1,42 @@
+function [t, v] = generateDriveCycle(params)
+%GENERATEDRIVECYCLE Creates stochastic mail delivery speed profile.
+%
+%   [t,v] = generateDriveCycle(params) returns time vector t and speed
+%   profile v (m/s) for the duration specified in params.N. The model
+%   follows the description in Section 4.1 of the report.
+%
+%   The speed profile consists of a base cruise speed with sinusoidal
+%   variation, additive Gaussian noise, and random stops of duration
+%   30-60 s every 120-180 s.
+
+T = params.N;          % total simulation time [s]
+dt = params.dt;
+
+% Parameters from the report
+vCruise = 35/3.6;      % 35 km/h in m/s
+Tcycle  = 300;         % cycle period [s]
+noiseStd = 2/3.6;      % speed variation [m/s]
+
+% Preallocate
+n = T/dt;
+t = (0:n-1)'*dt;
+v = vCruise*(1 + 0.2*sin(2*pi*t/Tcycle)) + noiseStd*randn(n,1);
+
+% Generate stop times
+nextStop = 120 + 60*rand;
+idx = 1;
+while idx <= n
+    if t(idx) >= nextStop
+        dur = 30 + 30*rand;
+        stopIdx = idx:min(n, idx+round(dur/dt));
+        v(stopIdx) = 0;
+        nextStop = nextStop + 120 + 60*rand;  % schedule next stop
+        idx = stopIdx(end);
+    end
+    idx = idx + 1;
+end
+
+% ensure non-negative speeds
+v(v<0) = 0;
+end
+

--- a/FTMPC_FCHEV/runMobypostFTMPC.m
+++ b/FTMPC_FCHEV/runMobypostFTMPC.m
@@ -1,0 +1,81 @@
+% runMobypostFTMPC.m
+% Main script to reproduce FTMPC vs FTDP results for Mobypost FCHEV
+%
+% This script generates the stochastic driving cycle, applies the fault
+% scenarios from the technical report and evaluates the fault-tolerant
+% MPC (FTMPC) controller against the Fault‑Tolerant Dynamic Programming
+% (FTDP) benchmark. The script collects hydrogen consumption and
+% computation time for each scenario and prints a table similar to
+% Table~3 in the report.
+%
+% This implementation follows the derivations provided in the report and
+% assumes the Optimization Toolbox (quadprog) is available.
+
+clear; clc;
+
+%% Simulation parameters
+params.dt      = 1;       % sample time [s]
+params.N       = 1800;    % mission duration [s]
+params.Hp      = 15;      % prediction horizon
+params.Hc      = 5;       % control horizon
+params.SoC0    = 0.45;    % initial state of charge
+params.SoCref  = 0.30;    % terminal reference
+
+% Vehicle and component data (subset of full table for brevity)
+params.mVeh    = 579;     % curb mass [kg]
+params.c_r     = 0.015;   % rolling resistance
+params.c_d     = 0.70;    % drag coefficient
+params.A_f     = 2.48;    % frontal area [m^2]
+params.rho_air = 1.26;    % air density [kg/m^3]
+params.g       = 9.81;    % gravity [m/s^2]
+params.eta_mec = 0.92;    % mechanical efficiency
+params.eta_inv = 0.95;    % inverter efficiency
+params.eta_em  = 0.92;    % motor efficiency
+
+% Battery model parameters
+params.Qbat    = 5.5*3600;           % capacity [As]
+params.Voc     = @(soc) 280 + 40*soc;% open circuit voltage [V]
+params.Rbat    = @(soc) 0.1 + 0.05*(1-soc); % internal resistance [Ohm]
+params.etabat  = 0.95;               % coulombic efficiency
+params.SoCmin  = 0.30;               % normal range
+params.SoCmax  = 0.90;
+
+% Fuel cell parameters
+params.Pfc_max = 1200;    % [W]
+params.Pfc_rate = 40;     % [W/s]
+params.eta_fc = @(P) (P>0).*0.43.*(1 - 0.8*(P/1200 - 550/1200).^2);
+params.rhoH2   = 120e6;   % J/kg energy density
+
+%% Generate driving cycle
+[time, speed] = generateDriveCycle(params);
+Pd = vehiclePowerDemand(time, speed, params);  % wheel power demand
+
+%% Define fault scenarios (Normal, Mild, Moderate, Severe)
+scenarios = {
+    struct('name','Normal','alpha_fc',0,'beta_fc',0,'delta_bat',0,'epsilon_bat',0),
+    struct('name','Mild',   'alpha_fc',0.10,'beta_fc',0,'delta_bat',0,'epsilon_bat',0.05),
+    struct('name','Moderate','alpha_fc',0.15,'beta_fc',0.20,'delta_bat',0.15,'epsilon_bat',0.25),
+    struct('name','Severe', 'alpha_fc',0.25,'beta_fc',0.30,'delta_bat',0.25,'epsilon_bat',0.40)
+    };
+
+results = struct();
+
+for i = 1:numel(scenarios)
+    faults = scenarios{i};
+    fprintf('Simulating scenario: %s\n', faults.name);
+    [mpcRes, dpRes] = simulateScenario(Pd, faults, params);
+    results.(faults.name).MPC = mpcRes;
+    results.(faults.name).DP  = dpRes;
+end
+
+%% Display results table
+fprintf('\nPerformance Comparison (H2 consumption in g)\n');
+fprintf('%10s %12s %12s %12s %12s\n','Scenario','MPC','DP','Perf(%)','Time ratio');
+scnNames = fieldnames(results);
+for i = 1:numel(scnNames)
+    sc = results.(scnNames{i});
+    perf = 100*sc.MPC.H2 / sc.DP.H2;
+    timeRatio = sc.MPC.time / sc.DP.time;
+    fprintf('%10s %12.1f %12.1f %12.1f %12.3f\n',scnNames{i},sc.MPC.H2,sc.DP.H2,perf,timeRatio);
+end
+

--- a/FTMPC_FCHEV/simulateFTDP.m
+++ b/FTMPC_FCHEV/simulateFTDP.m
@@ -1,0 +1,66 @@
+function H2 = simulateFTDP(Pd, faults, params)
+%SIMULATEFTDP Simplified fault‑tolerant Dynamic Programming benchmark.
+%
+%   H2 = simulateFTDP(Pd, faults, params) computes the globally optimal
+%   hydrogen consumption for the given demand profile using a discrete DP
+%   approach. The implementation is simplified for clarity and follows the
+%   structure of Section 10 in the report.
+
+N = params.N;
+dt = params.dt;
+
+% fault‑dependent limits
+SoCmin = params.SoCmin + 0.05*sqrt(faults.delta_bat^2 + faults.epsilon_bat^2);
+SoCmax = params.SoCmax - 0.05*sqrt(faults.delta_bat^2 + faults.epsilon_bat^2);
+Pfc_max = params.Pfc_max*(1 - faults.beta_fc);
+
+a = 0:50:Pfc_max;                 % control grid (fuel cell power)
+S = linspace(SoCmin, SoCmax, 61); % SoC grid
+ns = numel(S); na = numel(a);
+
+V = inf(ns, N+1);
+V(:,N+1) = (S - params.SoCref).^2;  % terminal cost
+
+for k = N:-1:1
+    for i = 1:ns
+        soc = S(i);
+        for j = 1:na
+            pfc = a(j);
+            [socn, h2, feasible] = batteryUpdate(soc, Pd(k), pfc, faults, params);
+            if ~feasible || socn < SoCmin || socn > SoCmax
+                continue; % infeasible move
+            end
+            idx = interp1(S,1:ns,socn,'nearest');
+            cost = h2 + V(idx,k+1);
+            if cost < V(i,k)
+                V(i,k) = cost;
+            end
+        end
+    end
+end
+
+idx0 = interp1(S,1:ns,params.SoC0,'nearest');
+H2 = V(idx0,1)*1000;  % g of hydrogen
+end
+
+function [socn, h2, feasible] = batteryUpdate(soc, Pd, Pfc, faults, params)
+% batteryUpdate compute next SoC and hydrogen consumption for given control
+Qbat = params.Qbat*(1 - faults.delta_bat);
+Voc  = params.Voc(soc);
+Vdc  = Voc;
+eta  = params.etabat;
+
+Pbat = Pd - Pfc*params.eta_inv;
+Ibat = Pbat / max(Vdc,1);
+socn = soc - params.dt*eta*Ibat/Qbat;
+
+eta_fc = params.eta_fc(Pfc).*(1 - faults.alpha_fc);
+if eta_fc <= 0
+    feasible = false;
+    h2 = inf;
+else
+    feasible = true;
+    h2 = params.dt*Pfc/(eta_fc*params.rhoH2);
+end
+end
+

--- a/FTMPC_FCHEV/simulateFTMPC.m
+++ b/FTMPC_FCHEV/simulateFTMPC.m
@@ -1,0 +1,113 @@
+function [H2, logs] = simulateFTMPC(Pd, faults, params)
+%SIMULATEFTMPC Fault-tolerant MPC simulation.
+%
+%   [H2, logs] = simulateFTMPC(Pd, faults, params) simulates the
+%   fault‑tolerant MPC controller for the given power demand Pd.
+%   The implementation closely follows the equations in Sections 7--9 of
+%   the report. The horizon is linearised at each step and solved as a QP
+%   using quadprog.
+
+N  = params.N;
+dt = params.dt;
+Hp = params.Hp;
+Hc = params.Hc;
+
+SoC = params.SoC0;
+Pfc = 0;                     % previous fuel cell power
+H2  = 0;                     % accumulated hydrogen [g]
+
+% cost weights
+w1 = 1; w2 = 1; w3 = 10;
+
+logs.Pfc = zeros(N,1);
+logs.SoC = zeros(N,1);
+
+for k = 1:N
+    % --- fault‑dependent parameters ---
+    Qbat = params.Qbat*(1 - faults.delta_bat);
+    Rbat = params.Rbat(SoC)*(1 + faults.epsilon_bat);
+    Voc  = params.Voc(SoC);
+    Vdc  = Voc - 0;   % neglect I*R for linearisation
+    etabat = params.etabat;
+
+    Pfc_max = params.Pfc_max*(1 - faults.beta_fc);
+    dPfc_max = params.Pfc_rate*(1 - faults.alpha_fc);
+    eta_fc = @(P) params.eta_fc(P).*(1 - faults.alpha_fc);
+
+    % build linear model matrices (A,B,Bw)
+    A = [1 dt*etabat*params.eta_inv/(Vdc*Qbat); 0 1];
+    B = [dt^2*etabat*params.eta_inv/(Vdc*Qbat); dt];
+    Bw= [-dt*etabat/(Vdc*Qbat); 0];
+
+    % prediction vectors
+    Pd_pred = Pd(k:min(k+Hp-1,N));
+    Pd_pred = [Pd_pred; Pd_pred(end)*ones(Hp-numel(Pd_pred),1)];
+
+    % matrices for prediction
+    [Phi, Psi_u, Psi_w] = buildPrediction(A,B,Bw,Hp,Hc);
+    xk = [SoC; Pfc];
+
+    % reference trajectories
+    Pfc_ref = zeros(Hp,1);   % prefer low fuel cell usage
+    Xref = [params.SoCref*ones(Hp,1) Pfc_ref];
+
+    % cost matrices
+    Q = blkdiag(kron(eye(Hp-1),diag([w3 w1])),diag([w3 w1]));
+    R = w2*eye(Hc);
+
+    H = 2*(Psi_u'*Q*Psi_u + R);
+    f = 2*Psi_u'*Q*(Phi*xk + Psi_w*Pd_pred - Xref(:));
+
+    % inequality constraints
+    % fuel cell power bounds
+    A1 = Psi_u(2:2:end,:);  % rows corresponding to Pfc predictions
+    b1 = (Pfc_max - Phi(2:2:end,:)*xk - Psi_w(2:2:end,:)*Pd_pred);
+
+    % rate constraints
+    A2 = [eye(Hc); -eye(Hc)];
+    b2 = [dPfc_max*ones(Hc,1); dPfc_max*ones(Hc,1)];
+
+    % aggregate
+    Aineq = [A1; -A1; A2];
+    bineq = [b1; Pfc_max*ones(size(b1)) - b1; b2];
+
+    % solve QP
+    options = optimoptions('quadprog','Display','off');
+    du = quadprog(H,f,Aineq,bineq,[],[],[],[],[],options);
+    du = du(1);   % apply only first control move
+
+    % update states
+    Pfc = Pfc + dt*du;
+    Pfc = max(0,min(Pfc,Pfc_max));
+    Pbat = Pd(k) - Pfc*params.eta_inv;
+    Ibat = Pbat / max(Vdc,1);
+    SoC = SoC - dt*etabat*Ibat/Qbat;
+
+    % hydrogen consumption
+    H2 = H2 + dt*Pfc ./ max(eta_fc(Pfc)*params.rhoH2,1);
+
+    logs.Pfc(k) = Pfc;
+    logs.SoC(k) = SoC;
+end
+
+H2 = H2*1000;   % convert kg to g
+end
+
+function [Phi, Psi_u, Psi_w] = buildPrediction(A,B,Bw,Hp,Hc)
+% Construct prediction matrices for time-invariant system
+n = size(A,1);
+Phi = zeros(n*Hp,n);
+Psi_u = zeros(n*Hp,Hc);
+Psi_w = zeros(n*Hp,Hp);
+
+for i=1:Hp
+    Phi((i-1)*n+1:i*n,:) = A^i;
+    for j=1:min(i,Hc)
+        Psi_u((i-1)*n+1:i*n,j) = A^(i-j)*B;
+    end
+    for j=1:i
+        Psi_w((i-1)*n+1:i*n,j) = A^(i-j)*Bw;
+    end
+end
+end
+

--- a/FTMPC_FCHEV/simulateScenario.m
+++ b/FTMPC_FCHEV/simulateScenario.m
@@ -1,0 +1,21 @@
+function [mpcRes, dpRes] = simulateScenario(Pd, faults, params)
+%SIMULATESCENARIO Execute FTMPC and FTDP for a given fault scenario.
+%
+%   [mpcRes, dpRes] = simulateScenario(Pd, faults, params) runs the
+%   FTMPC controller and FTDP benchmark for the power demand profile Pd
+%   under the fault levels specified in faults.
+
+% ---- FTMPC ------------------------------------------------------------
+mpcStart = tic;
+[H2_mpc, ~] = simulateFTMPC(Pd, faults, params);
+mpcRes.H2   = H2_mpc;
+mpcRes.time = toc(mpcStart);
+
+% ---- FTDP -------------------------------------------------------------
+dpStart = tic;
+[H2_dp] = simulateFTDP(Pd, faults, params);
+dpRes.H2   = H2_dp;
+dpRes.time = toc(dpStart);
+
+end
+

--- a/FTMPC_FCHEV/vehiclePowerDemand.m
+++ b/FTMPC_FCHEV/vehiclePowerDemand.m
@@ -1,0 +1,29 @@
+function Pd = vehiclePowerDemand(t, v, params)
+%VEHICLEPOWERDEMAND Compute DC bus power demand from speed profile.
+%
+%   Pd = vehiclePowerDemand(t, v, params) returns the electric power
+%   demand at the DC bus for the given speed profile v (m/s). The model
+%   includes rolling resistance, aerodynamic drag and inertial effects.
+%   Drivetrain efficiencies are included as in the report.
+
+m   = params.mVeh;
+g   = params.g;
+c_r = params.c_r;
+c_d = params.c_d;
+A_f = params.A_f;
+rho = params.rho_air;
+eta = params.eta_mec*params.eta_inv*params.eta_em;
+
+% numerical differentiation for acceleration
+acc = [diff(v)./diff(t); 0];
+
+F_inert = m.*acc;
+F_roll  = c_r*m*g*ones(size(v));
+F_aero  = 0.5*rho*A_f*c_d.*v.^2;
+F_total = F_inert + F_roll + F_aero;
+P_wheel = F_total.*v;
+
+Pd = P_wheel./eta;   % DC bus power demand
+
+end
+


### PR DESCRIPTION
## Summary
- add MATLAB scripts implementing the fault-tolerant MPC and dynamic programming benchmark for the Mobypost FCHEV case study
- include driving-cycle generator, vehicle power model, and scenario runner producing hydrogen consumption table

## Testing
- `matlab -batch "run('FTMPC_FCHEV/runMobypostFTMPC.m')"` *(fails: command not found)*
- `octave --quiet FTMPC_FCHEV/runMobypostFTMPC.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0362d888332867f9374d6061ecb